### PR TITLE
Change sklearn to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ install_requires = [
     'scipy',
     'cython >= ' + min_cython_ver,
     'fastdtw',
-    'sklearn',
+    'scikit-learn',
     'pysptk >= 0.1.17',
     'tqdm',
 ]


### PR DESCRIPTION
As mentioned on the PyPI page (https://pypi.org/project/sklearn/), the "sklearn" package is just an alias for "scikit-learn". This saves the installation of an empty package.